### PR TITLE
feat: add Quarto Wizard schema and snippets

### DIFF
--- a/_extensions/pseudocode/_schema.yml
+++ b/_extensions/pseudocode/_schema.yml
@@ -1,0 +1,58 @@
+$schema: https://m.canouil.dev/quarto-wizard/assets/schema/v1/extension-schema.json
+
+options:
+  pseudocode:
+    type: object
+    description: Global pseudocode caption and reference settings.
+    properties:
+      caption-prefix:
+        type: string
+        default: Algorithm
+        description: Prefix used for generated pseudocode captions.
+      reference-prefix:
+        type: string
+        default: Algorithm
+        description: Prefix used for pseudocode cross-reference text.
+      caption-number:
+        type: boolean
+        default: true
+        description: Show numbering in pseudocode captions.
+      caption-align:
+        type: string
+        enum: [left, center, right]
+        default: left
+        description: Alignment for pseudocode captions.
+
+attributes:
+  CodeBlock:
+    label:
+      type: string
+      description: Cross-reference label, typically starting with alg-.
+    html-indent-size:
+      type: string
+      description: HTML indent size for pseudocode.js output.
+    html-comment-delimiter:
+      type: string
+      description: HTML comment delimiter token.
+    html-line-number:
+      type: boolean
+      description: Show line numbers in HTML output.
+    html-line-number-punc:
+      type: string
+      description: Punctuation used after line numbers in HTML output.
+    html-no-end:
+      type: boolean
+      description: Hide end statements in HTML output.
+    pdf-placement:
+      type: string
+      description: LaTeX algorithm placement token in PDF output.
+    pdf-line-number:
+      type: boolean
+      description: Show line numbers in PDF output.
+    pdf-comment-delimiter:
+      type: string
+      description: Comment delimiter token in PDF output.
+
+classes:
+  pseudocode:
+    description: Code block language class handled by the pseudocode filter.

--- a/_extensions/pseudocode/_snippets.json
+++ b/_extensions/pseudocode/_snippets.json
@@ -1,0 +1,37 @@
+{
+  "Pseudocode filter setup": {
+    "prefix": "setup",
+    "body": [
+      "filters:",
+      "  - pseudocode"
+    ],
+    "description": "Enable pseudocode filter for code block rendering."
+  },
+  "Pseudocode global options": {
+    "prefix": "options",
+    "body": [
+      "pseudocode:",
+      "  caption-prefix: \"${1:Algorithm}\"",
+      "  reference-prefix: \"${2:Algorithm}\"",
+      "  caption-number: ${3:true}",
+      "  caption-align: \"${4:left}\""
+    ],
+    "description": "Insert global pseudocode caption and reference settings."
+  },
+  "Pseudocode code block": {
+    "prefix": "block",
+    "body": [
+      "```pseudocode",
+      "#| label: ${1:alg-example}",
+      "#| html-line-number: ${2:true}",
+      "\\begin{algorithm}",
+      "\\caption{${3:Example algorithm}}",
+      "\\begin{algorithmic}",
+      "${4:State x \\gets 1}",
+      "\\end{algorithmic}",
+      "\\end{algorithm}",
+      "```"
+    ],
+    "description": "Insert a pseudocode code block with common options."
+  }
+}


### PR DESCRIPTION
Adds Quarto Wizard support files for this extension to improve authoring and make configuration less error-prone in VSCode/Positron when using Quarto Wizard.

### What this adds
- _extensions/pseudocode/_schema.yml with relevant extension metadata for completion and validation.
- _extensions/pseudocode/_snippets.json with practical insertion snippets.

### Why this helps
- Better completion and hover guidance for extension-specific configuration.
- Faster setup through reusable snippets.
- Reduced authoring mistakes.

### References
- Schema specification: https://m.canouil.dev/quarto-wizard/reference/schema-specification.html
- Snippet specification: https://m.canouil.dev/quarto-wizard/reference/snippet-specification.html
