### PR TITLE
Switch to algpseudocodex, add new options to match its features

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@
 
 🇺🇸 [README](README.md) | 🇨🇳 [中文说明](README.zh.md)
 
-A Quarto extension to render pseudocode for `html` and `pdf` document. It's based on [pseudocode.js](https://github.com/SaswatPadhi/pseudocode.js) for `html` document, `algorithm` and `algpseudocode` package for `pdf` document.
+A Quarto extension to render pseudocode for `html` and `pdf` document. It's based on [pseudocode.js](https://github.com/SaswatPadhi/pseudocode.js) for `html` document, `algorithm` and `algpseudocodex` package for `pdf` document.
 
 ## Installing
 

--- a/README.zh.md
+++ b/README.zh.md
@@ -8,7 +8,7 @@
 
 🇺🇸 [README](README.md) | 🇨🇳 [中文说明](README.zh.md)
 
-一个用于在 `html` 和 `pdf` 文档中渲染伪代码的 Quarto 扩展。`html` 文档基于 [pseudocode.js](https://github.com/SaswatPadhi/pseudocode.js) 实现，`pdf` 文档基于 `algorithm` 和 `algpseudocode` 包实现。
+一个用于在 `html` 和 `pdf` 文档中渲染伪代码的 Quarto 扩展。`html` 文档基于 [pseudocode.js](https://github.com/SaswatPadhi/pseudocode.js) 实现，`pdf` 文档基于 `algorithm` 和 `algpseudocodex` 包实现。
 
 ## 安装
 

--- a/_extensions/pseudocode/_schema.yml
+++ b/_extensions/pseudocode/_schema.yml
@@ -52,6 +52,21 @@ attributes:
     pdf-comment-delimiter:
       type: string
       description: Comment delimiter token in PDF output.
+    pdf-no-end:
+      type: boolean
+      description: Hide end statements in PDF output.
+    pdf-indent-lines:
+      type: boolean
+      description: Show indent guide lines in PDF output.
+    pdf-italic-comment:
+      type: boolean
+      description: Italic comments in PDF output.
+    pdf-right-comment:
+      type: boolean
+      description: Right justified comments in PDF output.
+    pdf-comment-color:
+      type: string
+      description: Color of the comments in PDF output.
 
 classes:
   pseudocode:

--- a/_extensions/pseudocode/pseudocode.lua
+++ b/_extensions/pseudocode/pseudocode.lua
@@ -3,9 +3,11 @@ local function ensure_html_deps()
     name = "pseudocode",
     version = "2.4.1",
     scripts = { "pseudocode.min.js" },
-    stylesheets = { "pseudocode.min.css" }
+    stylesheets = { "pseudocode.min.css" },
   })
-  quarto.doc.include_text("in-header", [[
+  quarto.doc.include_text(
+    "in-header",
+    [[
     <style type="text/css">
     .ps-root .ps-algorithm {
       border-top: 2px solid;
@@ -15,8 +17,11 @@ local function ensure_html_deps()
       text-align: left;
     }
     </style>
-  ]])
-  quarto.doc.include_text("after-body", [[
+  ]]
+  )
+  quarto.doc.include_text(
+    "after-body",
+    [[
     <script type="text/javascript">
     (function(d) {
       d.querySelectorAll(".pseudocode-container").forEach(function(el) {
@@ -48,7 +53,8 @@ local function ensure_html_deps()
       });
     })(document);
     </script>
-  ]])
+  ]]
+  )
 end
 
 local function nil_to_default(value, default)
@@ -61,9 +67,14 @@ end
 
 local function ensure_latex_deps()
   quarto.doc.use_latex_package("algorithm")
-  quarto.doc.use_latex_package("algpseudocodex", "noEnd=false, indLines=false, italicComments=false, rightComments=false, commentColor=black, beginComment=//~")
+  quarto.doc.use_latex_package(
+    "algpseudocodex",
+    "noEnd=false, indLines=false, italicComments=false, rightComments=false, commentColor=black, beginComment=//~"
+  )
   quarto.doc.use_latex_package("caption")
-  quarto.doc.include_text("in-header", [[
+  quarto.doc.include_text(
+    "in-header",
+    [[
     \makeatletter
     \newcommand\fs@nocaption{
       \def\@fs@cfont{\bfseries}
@@ -77,7 +88,8 @@ local function ensure_latex_deps()
     \newcommand{\algpxSetBeginComment}[1]{\renewcommand{\algpx@beginComment}{#1}}
     \newcommand{\algpxSetEndComment}[1]{\renewcommand{\algpx@endComment}{#1}}
     \makeatother
-  ]])
+  ]]
+  )
 end
 
 local function extract_source_code_options(source_code, render_type)
@@ -94,8 +106,8 @@ local function extract_source_code_options(source_code, render_type)
         if idx_start and idx_end and idx_end + 1 < #str then
           k = string.sub(str, 1, idx_start - 1)
           v = string.sub(str, idx_end + 1)
-          v = string.gsub(v, "^%s*\"", "")
-          v = string.gsub(v, "\"%s*$", "")
+          v = string.gsub(v, '^%s*"', "")
+          v = string.gsub(v, '"%s*$', "")
 
           options[k] = v
         else
@@ -178,7 +190,7 @@ local function render_pseudocode_block_html(global_options)
       end
 
       return outer_el
-    end
+    end,
   }
 
   return filter
@@ -190,7 +202,10 @@ local function render_pseudocode_block_latex(global_options)
   if global_options.caption_number then
     quarto.doc.include_text("before-body", "\\floatname{algorithm}{" .. global_options.caption_prefix .. "}")
   else
-    quarto.doc.include_text("in-header", "\\DeclareCaptionLabelFormat{algnonumber}{" .. global_options.caption_prefix .. "}")
+    quarto.doc.include_text(
+      "in-header",
+      "\\DeclareCaptionLabelFormat{algnonumber}{" .. global_options.caption_prefix .. "}"
+    )
     quarto.doc.include_text("before-body", "\\captionsetup[algorithm]{labelformat=algnonumber}")
   end
 
@@ -215,63 +230,73 @@ local function render_pseudocode_block_latex(global_options)
       end
 
       local options, source_code = extract_source_code_options(el.text, "pdf")
+      local algpseudocodex_options = ""
 
-      local algpx_options = ""
       options["pdf-no-end"] = nil_to_default(options["pdf-no-end"], "false")
       options["pdf-indent-lines"] = nil_to_default(options["pdf-indent-lines"], "false")
       options["pdf-italic-comment"] = nil_to_default(options["pdf-italic-comment"], "false")
       options["pdf-right-comment"] = nil_to_default(options["pdf-right-comment"], "false")
       options["pdf-comment-color"] = nil_to_default(options["pdf-comment-color"], "black")
       options["pdf-comment-delimiter"] = nil_to_default(options["pdf-comment-delimiter"], "//"):gsub("%%", "%%%%")
+      
       if string.lower(options["pdf-no-end"]) == "true" then
-        algpx_options = algpx_options .. [[
-\setbool{algpx@noEnd}{true}%%
-\algtext*{EndWhile}%%
-\algtext*{EndFor}%%
-\algtext*{EndLoop}%%
-\algtext*{EndIf}%%
-\algtext*{EndProcedure}%%
-\algtext*{EndFunction}%%
-\algtext*{EndStructure}%%
-\algtext*{EndClass}%%
-\algtext*{EndProperties}%%
-\algtext*{EndMethods}%%
-\pretocmd{\EndWhile}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndFor}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndLoop}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndIf}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndProcedure}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndFunction}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndStructure}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndClass}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndProperties}{\algpxEndIndentHelper}{}{}%%
-\pretocmd{\EndMethods}{\algpxEndIndentHelper}{}{}%%
-]]
+        algpseudocodex_options = algpseudocodex_options
+          .. [[
+          \setbool{algpx@noEnd}{true}%%
+          \algtext*{EndWhile}%%
+          \algtext*{EndFor}%%
+          \algtext*{EndLoop}%%
+          \algtext*{EndIf}%%
+          \algtext*{EndProcedure}%%
+          \algtext*{EndFunction}%%
+          \algtext*{EndStructure}%%
+          \algtext*{EndClass}%%
+          \algtext*{EndProperties}%%
+          \algtext*{EndMethods}%%
+          \pretocmd{\EndWhile}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndFor}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndLoop}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndIf}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndProcedure}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndFunction}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndStructure}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndClass}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndProperties}{\algpxEndIndentHelper}{}{}%%
+          \pretocmd{\EndMethods}{\algpxEndIndentHelper}{}{}%%
+        ]]
       end
       if string.lower(options["pdf-indent-lines"]) == "true" then
-        algpx_options = algpx_options .. "\\setbool{algpx@indLines}{true}%%\n"
+        algpseudocodex_options = algpseudocodex_options .. "\\setbool{algpx@indLines}{true}%%\n"
       end
       if string.lower(options["pdf-italic-comment"]) == "true" then
-        algpx_options = algpx_options .. "\\setbool{algpx@italicComments}{true}%%\n"
+        algpseudocodex_options = algpseudocodex_options .. "\\setbool{algpx@italicComments}{true}%%\n"
       end
       if string.lower(options["pdf-right-comment"]) == "true" then
-        algpx_options = algpx_options .. "\\setbool{algpx@rightComments}{true}%%\n"
+        algpseudocodex_options = algpseudocodex_options .. "\\setbool{algpx@rightComments}{true}%%\n"
       end
       if string.lower(options["pdf-comment-color"]) ~= "black" then
-        algpx_options = algpx_options .. "\\algpxSetCommentColor{" .. options["pdf-comment-color"] .. "}%%\n"
+        algpseudocodex_options = algpseudocodex_options .. "\\algpxSetCommentColor{" .. options["pdf-comment-color"] .. "}%%\n"
       end
       if string.lower(options["pdf-comment-delimiter"]) ~= "//" then
-        algpx_options = algpx_options .. "\\algpxSetBeginComment{" .. options["pdf-comment-delimiter"] .. "~}%%\n"
+        algpseudocodex_options = algpseudocodex_options
+          .. "\\algpxSetBeginComment{"
+          .. options["pdf-comment-delimiter"]
+          .. "~}%%\n"
       end
 
       options["pdf-placement"] = nil_to_default(options["pdf-placement"], "H")
-      source_code = string.gsub(source_code, "\\begin{algorithm}%s*\n",
-        "\\begin{algorithm}[" .. options["pdf-placement"] .. "]\n")
+      source_code = string.gsub(
+        source_code,
+        "\\begin{algorithm}%s*\n",
+        "\\begin{algorithm}[" .. options["pdf-placement"] .. "]\n"
+      )
 
       if string.lower(nil_to_default(options["pdf-line-number"], "true")) == "true" then
-        source_code = string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[1]\n" .. algpx_options)
+        source_code =
+          string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[1]\n" .. algpseudocodex_options)
       else
-        source_code = string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[0]\n" .. algpx_options)
+        source_code =
+          string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[0]\n" .. algpseudocodex_options)
       end
 
       if options["label"] then
@@ -279,13 +304,17 @@ local function render_pseudocode_block_latex(global_options)
       end
 
       if string.find(source_code, "\\caption{") then
-        source_code = "\\floatstyle{ruled}\n\\restylefloat{algorithm}\n" .. source_code .. "\n\\floatstyle{plain}\n"
+        source_code = "\\floatstyle{ruled}\n\\restylefloat{algorithm}\n"
+          .. source_code
+          .. "\n\\floatstyle{plain}\n"
       else
-        source_code = "\\floatstyle{nocaption}\n\\restylefloat{algorithm}\n" .. source_code .. "\n\\floatstyle{plain}\n"
+        source_code = "\\floatstyle{nocaption}\n\\restylefloat{algorithm}\n"
+          .. source_code
+          .. "\n\\floatstyle{plain}\n"
       end
 
       return pandoc.RawInline("latex", source_code)
-    end
+    end,
   }
 
   return filter
@@ -295,7 +324,7 @@ local function render_pseudocode_block(global_options)
   local filter = {
     CodeBlock = function(el)
       return el
-    end
+    end,
   }
 
   if quarto.doc.is_format("html") then
@@ -329,7 +358,7 @@ local function render_pseudocode_ref_html(global_options)
           return link
         end
       end
-    end
+    end,
   }
 
   return filter
@@ -341,10 +370,12 @@ local function render_pseudocode_ref_latex(global_options)
       local cite_text = pandoc.utils.stringify(el.content)
 
       if string.match(cite_text, "^@algo-") then
-        return pandoc.RawInline("latex",
-          global_options.reference_prefix .. "~\\ref{" .. string.gsub(cite_text, "^@", "") .. "}")
+        return pandoc.RawInline(
+          "latex",
+          global_options.reference_prefix .. "~\\ref{" .. string.gsub(cite_text, "^@", "") .. "}"
+        )
       end
-    end
+    end,
   }
 
   return filter
@@ -354,7 +385,7 @@ local function render_pseudocode_ref(global_options)
   local filter = {
     Cite = function(el)
       return el
-    end
+    end,
   }
 
   if quarto.doc.is_format("html") then
@@ -375,18 +406,21 @@ function Pandoc(doc)
     number_with_in_chapter = false,
     html_chapter_level = nil,
     html_current_number = 1,
-    html_identifier_number_mapping = {}
+    html_identifier_number_mapping = {},
   }
 
   if doc.meta["pseudocode"] then
-    global_options.caption_prefix = pandoc.utils.stringify(nil_to_default(doc.meta["pseudocode"]["caption-prefix"],
-      global_options.caption_prefix))
-    global_options.reference_prefix = pandoc.utils.stringify(nil_to_default(doc.meta["pseudocode"]["reference-prefix"],
-      global_options.reference_prefix))
-    global_options.caption_number = nil_to_default(doc.meta["pseudocode"]["caption-number"],
-      global_options.caption_number)
-    global_options.caption_align = pandoc.utils.stringify(nil_to_default(doc.meta["pseudocode"]["caption-align"],
-      global_options.caption_align))
+    global_options.caption_prefix = pandoc.utils.stringify(
+      nil_to_default(doc.meta["pseudocode"]["caption-prefix"], global_options.caption_prefix)
+    )
+    global_options.reference_prefix = pandoc.utils.stringify(
+      nil_to_default(doc.meta["pseudocode"]["reference-prefix"], global_options.reference_prefix)
+    )
+    global_options.caption_number =
+      nil_to_default(doc.meta["pseudocode"]["caption-number"], global_options.caption_number)
+    global_options.caption_align = pandoc.utils.stringify(
+      nil_to_default(doc.meta["pseudocode"]["caption-align"], global_options.caption_align)
+    )
   end
 
   if doc.meta["book"] then
@@ -397,7 +431,11 @@ function Pandoc(doc)
       local renders = doc.meta["book"]["render"]
 
       for _, render in pairs(renders) do
-        if render["file"] and render["number"] and pandoc.utils.stringify(render["file"]) == input_qmd_filename then
+        if
+          render["file"]
+          and render["number"]
+          and pandoc.utils.stringify(render["file"]) == input_qmd_filename
+        then
           global_options.html_chapter_level = pandoc.utils.stringify(render["number"])
         end
       end

--- a/_extensions/pseudocode/pseudocode.lua
+++ b/_extensions/pseudocode/pseudocode.lua
@@ -61,7 +61,7 @@ end
 
 local function ensure_latex_deps()
   quarto.doc.use_latex_package("algorithm")
-  quarto.doc.use_latex_package("algpseudocode")
+  quarto.doc.use_latex_package("algpseudocodex", "noEnd=false, indLines=false, italicComments=false, rightComments=false, commentColor=black, beginComment=//~")
   quarto.doc.use_latex_package("caption")
   quarto.doc.include_text("in-header", [[
     \makeatletter
@@ -72,6 +72,10 @@ local function ensure_latex_deps()
       \def\@fs@post{\kern2pt\hrule}%
       \def\@fs@mid{\hrule\kern2pt}%
       \let\@fs@iftopcapt\iftrue}
+    \newcommand{\algpxEndIndentHelper}{\algpx@endIndent}
+    \newcommand{\algpxSetCommentColor}[1]{\renewcommand{\algpx@commentColor}{#1}}
+    \newcommand{\algpxSetBeginComment}[1]{\renewcommand{\algpx@beginComment}{#1}}
+    \newcommand{\algpxSetEndComment}[1]{\renewcommand{\algpx@endComment}{#1}}
     \makeatother
   ]])
 end
@@ -212,23 +216,62 @@ local function render_pseudocode_block_latex(global_options)
 
       local options, source_code = extract_source_code_options(el.text, "pdf")
 
-      local comment_delimiter = nil_to_default(options["pdf-comment-delimiter"], "//")
-      local placeholder = "#1"
-
-      if quarto.doc.is_format("beamer") then
-        placeholder = "####1"
+      local algpx_options = ""
+      options["pdf-no-end"] = nil_to_default(options["pdf-no-end"], "false")
+      options["pdf-indent-lines"] = nil_to_default(options["pdf-indent-lines"], "false")
+      options["pdf-italic-comment"] = nil_to_default(options["pdf-italic-comment"], "false")
+      options["pdf-right-comment"] = nil_to_default(options["pdf-right-comment"], "false")
+      options["pdf-comment-color"] = nil_to_default(options["pdf-comment-color"], "black")
+      options["pdf-comment-delimiter"] = nil_to_default(options["pdf-comment-delimiter"], "//"):gsub("%%", "%%%%")
+      if string.lower(options["pdf-no-end"]) == "true" then
+        algpx_options = algpx_options .. [[
+\setbool{algpx@noEnd}{true}%%
+\algtext*{EndWhile}%%
+\algtext*{EndFor}%%
+\algtext*{EndLoop}%%
+\algtext*{EndIf}%%
+\algtext*{EndProcedure}%%
+\algtext*{EndFunction}%%
+\algtext*{EndStructure}%%
+\algtext*{EndClass}%%
+\algtext*{EndProperties}%%
+\algtext*{EndMethods}%%
+\pretocmd{\EndWhile}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndFor}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndLoop}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndIf}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndProcedure}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndFunction}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndStructure}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndClass}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndProperties}{\algpxEndIndentHelper}{}{}%%
+\pretocmd{\EndMethods}{\algpxEndIndentHelper}{}{}%%
+]]
       end
-
-      source_code = "\\algrenewcommand{\\algorithmiccomment}[1]{ " .. comment_delimiter .. " " .. placeholder .. "}\n".. source_code
+      if string.lower(options["pdf-indent-lines"]) == "true" then
+        algpx_options = algpx_options .. "\\setbool{algpx@indLines}{true}%%\n"
+      end
+      if string.lower(options["pdf-italic-comment"]) == "true" then
+        algpx_options = algpx_options .. "\\setbool{algpx@italicComments}{true}%%\n"
+      end
+      if string.lower(options["pdf-right-comment"]) == "true" then
+        algpx_options = algpx_options .. "\\setbool{algpx@rightComments}{true}%%\n"
+      end
+      if string.lower(options["pdf-comment-color"]) ~= "black" then
+        algpx_options = algpx_options .. "\\algpxSetCommentColor{" .. options["pdf-comment-color"] .. "}%%\n"
+      end
+      if string.lower(options["pdf-comment-delimiter"]) ~= "//" then
+        algpx_options = algpx_options .. "\\algpxSetBeginComment{" .. options["pdf-comment-delimiter"] .. "~}%%\n"
+      end
 
       options["pdf-placement"] = nil_to_default(options["pdf-placement"], "H")
       source_code = string.gsub(source_code, "\\begin{algorithm}%s*\n",
         "\\begin{algorithm}[" .. options["pdf-placement"] .. "]\n")
 
       if string.lower(nil_to_default(options["pdf-line-number"], "true")) == "true" then
-        source_code = string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[1]\n")
+        source_code = string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[1]\n" .. algpx_options)
       else
-        source_code = string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[0]\n")
+        source_code = string.gsub(source_code, "\\begin{algorithmic}%s*\n", "\\begin{algorithmic}[0]\n" .. algpx_options)
       end
 
       if options["label"] then

--- a/examples/beamer/beamer.qmd
+++ b/examples/beamer/beamer.qmd
@@ -51,3 +51,42 @@ Test atoms is shown as @algo-test-atoms.
 \end{algorithmic}
 \end{algorithm}
 ```
+
+::: {.content-visible when-format="pdf"}
+## Test `algpseudocodex` features
+
+```pseudocode
+#| pdf-no-end: true
+#| pdf-indent-lines: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-italic-comment: true
+#| pdf-right-comment: true
+#| pdf-comment-color: gray
+#| pdf-comment-delimiter: "\#"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+:::

--- a/examples/book/02-examples.qmd
+++ b/examples/book/02-examples.qmd
@@ -176,3 +176,144 @@ Test statements and comments is shown as @algo-test-statements-and-comments.
 ```
 
 \listofalgorithms{}
+
+::: {.content-visible when-format="pdf"}
+## Test `algpseudocodex` features
+
+```pseudocode
+#| pdf-no-end: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-indent-lines: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-no-end: true
+#| pdf-indent-lines: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-italic-comment: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-right-comment: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-comment-color: "blue"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-comment-delimiter: "\%"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-italic-comment: true
+#| pdf-right-comment: true
+#| pdf-comment-color: gray
+#| pdf-comment-delimiter: "\#"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+:::

--- a/examples/book/02-examples.qmd
+++ b/examples/book/02-examples.qmd
@@ -175,8 +175,6 @@ Test statements and comments is shown as @algo-test-statements-and-comments.
 \end{algorithm}
 ```
 
-\listofalgorithms{}
-
 ::: {.content-visible when-format="pdf"}
 ## Test `algpseudocodex` features
 
@@ -317,3 +315,5 @@ Test statements and comments is shown as @algo-test-statements-and-comments.
 \end{algorithm}
 ```
 :::
+
+\listofalgorithms{}

--- a/examples/simple/simple.qmd
+++ b/examples/simple/simple.qmd
@@ -226,7 +226,7 @@ Test statements and comments is shown as @algo-test-statements-and-comments.
 ## Test pseudocode in custom block
 
 ::: {.content-visible when-format="html"}
-Test content visible in html format is show as @algo-test-content-visible-html.
+Test content visible in html format is shown as @algo-test-content-visible-html.
 
 ```pseudocode
 #| label: algo-test-content-visible-html
@@ -243,7 +243,7 @@ Test content visible in html format is show as @algo-test-content-visible-html.
 :::
 
 ::: {.content-visible when-format="pdf"}
-Test content visible in pdf format is show as @algo-test-content-visible-pdf.
+Test content visible in pdf format is shown as @algo-test-content-visible-pdf.
 
 ```pseudocode
 #| label: algo-test-content-visible-pdf
@@ -259,7 +259,7 @@ Test content visible in pdf format is show as @algo-test-content-visible-pdf.
 ```
 :::
 
-Test callout is show as @algo-test-callout.
+Test callout is shown as @algo-test-callout.
 
 ::: {.callout-note}
 ```pseudocode
@@ -271,6 +271,147 @@ Test callout is show as @algo-test-callout.
 \begin{algorithmic}
 \Procedure{Test-Callout}{}
   \State CALLOUT TEST
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+:::
+
+::: {.content-visible when-format="pdf"}
+## Test `algpseudocodex` features
+
+```pseudocode
+#| pdf-no-end: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-indent-lines: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-no-end: true
+#| pdf-indent-lines: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-italic-comment: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-right-comment: true
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-comment-color: "blue"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-comment-delimiter: "\%"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
+\EndProcedure
+\end{algorithmic}
+\end{algorithm}
+```
+
+```pseudocode
+#| pdf-italic-comment: true
+#| pdf-right-comment: true
+#| pdf-comment-color: gray
+#| pdf-comment-delimiter: "\#"
+
+\begin{algorithm}
+\begin{algorithmic}
+\Procedure{Test-While}{$n$}
+  \State $i \gets 0$
+  \While{$i < n$}
+    \Comment{this is a loop}
+    \Print $i$
+    \State $i \gets i + 1$
+  \EndWhile
 \EndProcedure
 \end{algorithmic}
 \end{algorithm}


### PR DESCRIPTION
This PR is a follow-up of https://github.com/leovan/quarto-pseudocode/issues/14 to use `algpseudocodex` instead of `algpseudocode`.

I added 5 new options to reflect the additional features supported by this package:
- `pdf-no-end` to hide end statements
- `pdf-indent-lines:` to show indent guide lines
- `pdf-italic-comment` for italic comments
- `pdf-right-comment` for right justified comments
- `pdf-comment-color` to set the color of the comments

I tested these features in multiple formats including beamer, and made sure that the default behavior is the same as before.

Let me know if you agree with these changes and if you have more suggestions!