### PR TITLE
Add html-indent-lines option

### DIFF
--- a/_extensions/pseudocode/_schema.yml
+++ b/_extensions/pseudocode/_schema.yml
@@ -43,6 +43,9 @@ attributes:
     html-no-end:
       type: boolean
       description: Hide end statements in HTML output.
+    html-indent-lines:
+      type: boolean
+      description: Show indent guide lines in HTML output.
     pdf-placement:
       type: string
       description: LaTeX algorithm placement token in PDF output.

--- a/_extensions/pseudocode/pseudocode.lua
+++ b/_extensions/pseudocode/pseudocode.lua
@@ -31,6 +31,7 @@ local function ensure_html_deps()
           lineNumber: el.dataset.lineNumber.toLowerCase() === "true",
           lineNumberPunc: el.dataset.lineNumberPunc,
           noEnd: el.dataset.noEnd.toLowerCase() === "true",
+          scopeLines: el.dataset.indentLines.toLowerCase() === "true",
           titlePrefix: el.dataset.captionPrefix,
         };
         pseudocode.renderElement(el.querySelector(".pseudocode"), pseudocodeOptions);
@@ -164,6 +165,7 @@ local function render_pseudocode_block_html(global_options)
       options["html-line-number"] = string.lower(nil_to_default(options["html-line-number"], "true"))
       options["html-line-number-punc"] = nil_to_default(options["html-line-number-punc"], ":")
       options["html-no-end"] = string.lower(nil_to_default(options["html-no-end"], "false"))
+      options["html-indent-lines"] = string.lower(nil_to_default(options["html-indent-lines"], "false"))
 
       local data_options = {}
       for k, v in pairs(options) do


### PR DESCRIPTION
This PR adds the `html-indent-lines` option to show indent guide lines in HTML, based on the `scopeLines` option from pseudocode.js (https://github.com/SaswatPadhi/pseudocode.js/pull/39). Just like the PDF version, it is disabled by default.